### PR TITLE
readme: clarify requirement for datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ pnpm i -g verdaccio-google-cloud
 ### Requirements
 
 * Google Cloud Account
+* Service account with 'Cloud Datastore Owner' role and read/write access to the bucket
 * Verdaccio server (see below)
 
 ```


### PR DESCRIPTION
I did not know that the service account needs access to datastore. I did not know that it uses it at all. This clarifies the requirement a bit.