### PR TITLE
Modified how key is generated for datastore.save

### DIFF
--- a/src/data-storage.js
+++ b/src/data-storage.js
@@ -79,7 +79,7 @@ class GoogleCloudDatabase implements IPluginStorage {
 
   add(name: string, cb: Callback): void {
     const datastore = this.data.datastore;
-    const key = datastore.key(this.kind);
+    const key = datastore.key([this.kind, name]);
     const data = {
       name: name
     };


### PR DESCRIPTION
Changed how key is generated for datastore.save to prevent duplicate entries. Key is now the name of the package.

According to Google Datastore documentation, if you provide both the kind and some value for a key, it will update the existing entity instead of adding a new entity everytime `save` is evoked with that key.