### PR TITLE
[Fix] Disable resumable uploads to Google Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,14 @@ store:
    ## default validation is, it can be overrided by 
    ## https://cloud.google.com/nodejs/docs/reference/storage/1.6.x/File.html#createWriteStream
    # validation: crc32c
+
+   ## Enable/disable resumable uploads to GC Storage
+   ## By default it's enabled in `@google-cloud/storage`
+   ## May cause failures for small package uploads so it is recommended to set it to `false`
+   ## @see https://stackoverflow.com/questions/53172050/google-cloud-storage-invalid-upload-request-error-bad-request
+   resumable: true
 ```
+
 Define `env` whether you want load the value from environment variables.
 
 > If you are willing to use some of `env` just **do not define** properties on

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -158,6 +158,11 @@ class GoogleCloudStorageHandler implements IPackageStorageManager {
       try {
         await file.save(this._convertToString(metadata), {
           validation: this.config.validation || defaultValidation,
+          /**
+           * When resumable is `undefined` - it will default to `true`as per GC Storage documentation:
+           * `Resumable uploads are automatically enabled and must be shut off explicitly by setting options.resumable to false`
+           * @see https://cloud.google.com/nodejs/docs/reference/storage/2.5.x/File#createWriteStream
+           */
           resumable: this.config.resumable
         });
         resolve(null);

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -157,7 +157,10 @@ class GoogleCloudStorageHandler implements IPackageStorageManager {
       const file = this._buildFilePath(name, pkgFileName);
       try {
         await file.save(this._convertToString(metadata), {
-          validation: this.config.validation || defaultValidation
+          validation: this.config.validation || defaultValidation,
+          // Disable resumable uploads to avoid random? failures from google cloud
+          // @see https://stackoverflow.com/questions/53172050/google-cloud-storage-invalid-upload-request-error-bad-request
+          resumable: false
         });
         resolve(null);
       } catch (err) {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -158,9 +158,7 @@ class GoogleCloudStorageHandler implements IPackageStorageManager {
       try {
         await file.save(this._convertToString(metadata), {
           validation: this.config.validation || defaultValidation,
-          // Disable resumable uploads to avoid random? failures from google cloud
-          // @see https://stackoverflow.com/questions/53172050/google-cloud-storage-invalid-upload-request-error-bad-request
-          resumable: false
+          resumable: this.config.resumable
         });
         resolve(null);
       } catch (err) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,8 @@ export interface VerdaccioConfigGoogleStorage extends Config {
   keyFilename?: string;
   // disable bucket validation
   validation?: GoogleValidation;
+  /** Enable/disable resumable uploads to GC Storage */
+  resumable?: boolean;
 }
 
 export type GoogleValidation = boolean | string;


### PR DESCRIPTION
Closes #14 

To avoid random failures from google cloud

See https://stackoverflow.com/questions/53172050/google-cloud-storage-invalid-upload-request-error-bad-request

_NOTE:_ I've tested locally on my verdaccio instance and this change fixed the issue.